### PR TITLE
Add color picker for single model parts

### DIFF
--- a/client/app/SimplePart.js
+++ b/client/app/SimplePart.js
@@ -231,7 +231,7 @@ const generateData = (startX) => [
         position: [-100 + startX, 122, 250],
         rotation: [-Math.PI / 2, 0, 0],
         scale: [3.5, 3, 1],
-        color: 0x0000ff
+        color: '#0000ff'
     },
     {
         id: getRandomId(),
@@ -239,7 +239,7 @@ const generateData = (startX) => [
         position: [400 + startX, 122, 250],
         rotation: [-Math.PI / 2, 0, 0],
         scale: [3.5, 3, 1],
-        color: 0x0000ff
+        color: '#0000ff'
     },
     {
         id: getRandomId(),
@@ -247,7 +247,7 @@ const generateData = (startX) => [
         position: [900 + startX, 122, 250],
         rotation: [-Math.PI / 2, 0, 0],
         scale: [3.5, 3, 1],
-        color: 0x0000ff
+        color: '#0000ff'
     },
     {
         id: getRandomId(),
@@ -255,7 +255,7 @@ const generateData = (startX) => [
         position: [1400 + startX, 122, 250],
         rotation: [-Math.PI / 2, 0, 0],
         scale: [3.5, 3, 1],
-        color: 0x0000ff
+        color: '#0000ff'
     },
     {
         id: getRandomId(),
@@ -263,7 +263,7 @@ const generateData = (startX) => [
         position: [-100 + startX, 122, 850],
         rotation: [-Math.PI / 2, 0, 0],
         scale: [3.5, 3, 1],
-        color: 0x0000ff
+        color: '#0000ff'
     },
     {
         id: getRandomId(),
@@ -271,7 +271,7 @@ const generateData = (startX) => [
         position: [400 + startX, 122, 850],
         rotation: [-Math.PI / 2, 0, 0],
         scale: [3.5, 3, 1],
-        color: 0x0000ff
+        color: '#0000ff'
     },
     {
         id: getRandomId(),
@@ -279,7 +279,7 @@ const generateData = (startX) => [
         position: [900 + startX, 122, 850],
         rotation: [-Math.PI / 2, 0, 0],
         scale: [3.5, 3, 1],
-        color: 0x0000ff
+        color: '#0000ff'
     },
     {
         id: getRandomId(),
@@ -287,7 +287,7 @@ const generateData = (startX) => [
         position: [1400 + startX, 122, 850],
         rotation: [-Math.PI / 2, 0, 0],
         scale: [3.5, 3, 1],
-        color: 0x0000ff
+        color: '#0000ff'
     },
 
 

--- a/client/app/components/viewer/Model.js
+++ b/client/app/components/viewer/Model.js
@@ -9,7 +9,8 @@ export default class Field3D extends Component {
         selectedMeshId: null,
         meshDataPosition: {x: 0, y: 0, z: 0},
         meshDataScale: {x: 0, y: 0, z: 0},
-        meshDataRotation: {x: 0, y: 0, z: 0}
+        meshDataRotation: {x: 0, y: 0, z: 0},
+        meshDataColor: this.props.modelColor
     }
 
     handleResize = (e) => {
@@ -22,13 +23,14 @@ export default class Field3D extends Component {
 
     onObjectClick = (data) => {
         let tmpData = this.refs['STLViewer'].getMeshById(data);
+
         this.setState({
             selectedMeshId: data,
             meshDataPosition: tmpData.position,
             meshDataScale: tmpData.scale,
-            meshDataRotation: tmpData.rotation
+            meshDataRotation: tmpData.rotation,
+            meshDataColor: tmpData.color
         });
-
     }
 
     componentDidMount = () => window.addEventListener('resize', this.handleResize);
@@ -36,7 +38,6 @@ export default class Field3D extends Component {
     getDimensions = (modelId) => this.refs['STLViewer'].getDimensions(modelId);
 
     changeData = (axis, type, e) => {
-        // console.log(e, axis, type, newValue);
         let newValue = parseFloat(e.target.value);
 
         if (type === 'position') {
@@ -61,6 +62,14 @@ export default class Field3D extends Component {
             });
             this.refs['STLViewer'].setMeshDataById(this.state.selectedMeshId, newState, 'rotation');
         }
+    }
+
+    changeColor = (e) => {
+        const color = e.target.value
+        this.setState({
+            meshDataColor: color
+        });
+        this.refs['STLViewer'].setMeshDataById(this.state.selectedMeshId, color, 'color');
     }
 
     changeNrOfModelParts = (e) => this.props.changeNrOfModelParts(parseInt(e.target.value))
@@ -121,6 +130,12 @@ export default class Field3D extends Component {
                         </div>
                         <div>
                             <label>z:</label><input type="number" value={this.state.meshDataRotation.z.toFixed(2)} step="0.01" onChange={this.changeData.bind(this, 'z', 'rotation')}/>
+                        </div>
+                    </div>
+                    <div>
+                        <h3>Color</h3>
+                        <div>
+                            <label>Pick a color:</label><input type="color" value={this.state.meshDataColor} onChange={this.changeColor.bind(this)}/>
                         </div>
                     </div>
                 </div>

--- a/client/app/components/viewer/STLViewer.js
+++ b/client/app/components/viewer/STLViewer.js
@@ -141,7 +141,7 @@ class STLViewer extends Component {
 
         this.loadPrimitives(this.props.primitiveData, loader).then((primitives) => {
             primitives.forEach((primitiveGeometry, index) => {
-                let mesh = new THREE.Mesh(primitiveGeometry, new THREE.MeshLambertMaterial({overdraw: true, color: '0xffffff'}));
+                let mesh = new THREE.Mesh(primitiveGeometry, new THREE.MeshLambertMaterial({overdraw: true, color: '#ffffff'}));
                 this.modelPrimitives[this.props.primitiveData[index].id] = mesh;
             });
 
@@ -179,7 +179,7 @@ class STLViewer extends Component {
 
         data.forEach((part, index)=>{
             let primitveMesh = this.modelPrimitives[part.primitiveId];
-            let mesh = new THREE.Mesh(primitveMesh.geometry, new THREE.MeshLambertMaterial({overdraw: true, color: '0xffffff'}));
+            let mesh = new THREE.Mesh(primitveMesh.geometry, new THREE.MeshLambertMaterial({overdraw: true, color: '#ffffff'}));
             // this.props.primitiveData[index].meshBB = new THREE.Box3().setFromObject(mesh);
             mesh.onObjectClick = this.props.onObjectClick.bind(null, part.id);
             mesh.userData.id = part.id;
@@ -187,7 +187,7 @@ class STLViewer extends Component {
             this.fullModelData[part.id] = {
                 visible: true,
                 meshIndex: this.fullModel.length - 1,
-                originalColor: part.color || 0xffffff,
+                originalColor: part.color || '#ffffff',
                 selected: false
             };
             mesh.position.set(...part.position);
@@ -237,7 +237,8 @@ class STLViewer extends Component {
         return {
             position: {x: tMesh.position.x,y: tMesh.position.y,z: tMesh.position.z},
             scale: {x: tMesh.scale.x,y: tMesh.scale.y,z: tMesh.scale.z},
-            rotation: {x: tMesh.rotation.x,y: tMesh.rotation.y,z: tMesh.rotation.z}
+            rotation: {x: tMesh.rotation.x,y: tMesh.rotation.y,z: tMesh.rotation.z},
+            color: this.fullModelData[meshId].originalColor
         };
     }
 
@@ -249,6 +250,8 @@ class STLViewer extends Component {
             tMesh.scale.set(data.x, data.y, data.z);
         } else if (type === 'rotation') {
             tMesh.rotation.set(data.x, data.y, data.z);
+        } else if (type === 'color') {
+            this.fullModelData[meshId].originalColor = data;
         }
         this.renderer.render(this.scene, this.camera);
     }


### PR DESCRIPTION
Related: https://github.com/alexadam/bridges/issues/2

One thing to note here is that those settings will disappear once you change the number of parts + they are set on a specific part instead of "part type".
The reason for this is that every time you change the number of parts `changeBridgeParts` is called, which on the other hand calls `generateData` and this function *always* calls `getRandomId`. It's problematic because, without a part specific ID, you are not able to reference it and know where color change should be stored.

This is a good base to start with, as it works without any issues now.